### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example:
 import React from 'react';
 import {render} from 'react-dom';
 
-import EditableLabel from 'editable-label';
+import EditableLabel from 'react-editable-label';
 
 class App extends React.Component {
     render () {


### PR DESCRIPTION
After installing the library and trying to follow the example, I realized that the name of the library in the example code is wrong. It's `editable-label` instead of `react-editable-label`.