### PR TITLE
Added types note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ if (app) {
     render(<App/>, app);
 }
 ```
+
+## Typescript Support
+
+Types are currently provided through [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) via npm.
+
+```
+npm i --save-dev @types/react-editable-label
+```


### PR DESCRIPTION
Added a note about how to install the associated Typescript types.

**Do note merge until https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68576 is merged**.